### PR TITLE
Remove serve-static middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "cors": "^2.5.3",
-    "express": "^4.12.1",
-    "serve-static": "^1.9.1"
+    "express": "^4.12.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -4,6 +4,6 @@ var express = require('express')
   , app = express();
 
 app.use(cors());
-app.use(serveStatic('./', {'index': ['index.html']}));
+app.use(express.static('./', {'index': ['index.html']}));
 
 app.listen(process.env.port || 1234, function(){ console.log("Server stared..."); });


### PR DESCRIPTION
Serve static is included in express. No need to install it.
