### PR TITLE
Prune dev packages and remove jspm folder

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -125,6 +125,9 @@ fi
   exitWithMessageOnError "jspm failed"
   ./node_modules/.bin/jspm bundle app/main --minify --inject
   exitWithMessageOnError "jspm bundle-sfx failed"
+  $NPM_CMD prune --production
+  exitWithMessageOnError "Npm prune failed for production environment"
+  rm -rf ./jspm_packages
   cd - > /dev/null
 
 ##################################################################################################################################


### PR DESCRIPTION
This PR will ensure that, after a deploy, **jspm** package will be deleted and **jspm_packages** folder as well. This will definitely reduce the slug size.
